### PR TITLE
Avoid repeated saves in notification loop

### DIFF
--- a/src/main/java/io/dealhub/demo/service/NotificationImpl.java
+++ b/src/main/java/io/dealhub/demo/service/NotificationImpl.java
@@ -30,10 +30,10 @@ public class NotificationImpl implements NotificationService {
                     notifyUser(verifier.getUserId(), plan, c.getChainId());
                     verifier.setNotified(true);
                     verifier.setDateNotification(LocalDateTime.now());
-                    planRepository.save(plan);
                 }
             }
         });
+        planRepository.save(plan);
     }
 
     private void notifyUser(Long userId, Plan plan, Long chainId) {


### PR DESCRIPTION
## Summary
- remove `planRepository.save` calls from inside loops
- save the plan once after updating verifiers

## Testing
- `mvn -q test` *(fails: project lacks pom.xml)*

------
https://chatgpt.com/codex/tasks/task_e_6882c3a653788333a1a4b217b2977f35